### PR TITLE
User Login & Account create endpoints working

### DIFF
--- a/password_manager_client/lib/main.dart
+++ b/password_manager_client/lib/main.dart
@@ -1,6 +1,10 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:password_manager_client/user_home.dart';
 import 'package:platform_device_id/platform_device_id.dart';
+import 'package:http/http.dart' as http;
+import 'package:status_alert/status_alert.dart';
 
 void main() {
   runApp(const MyApp());
@@ -10,9 +14,9 @@ class MyApp extends StatelessWidget {
   const MyApp({super.key});
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return const MaterialApp(
       title: 'Password Manager',
-      home: const MyHomePage(title: 'Password Manager'),
+      home: MyHomePage(title: 'Password Manager'),
     );
   }
 }
@@ -26,9 +30,8 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-
   final TextEditingController _userphone = TextEditingController();
-  String? _androidId;
+  late String _androidId;
 
   // function to get the android id of phone
   void getInfo() async {
@@ -36,7 +39,144 @@ class _MyHomePageState extends State<MyHomePage> {
 
     // Update ID
     setState(() {
-      _androidId = result;
+      _androidId = result ?? "";
+    });
+  }
+
+  void userLogin() async {
+    bool account = false;
+    print("Running...");
+    String? base =
+        "https://passwordmanagerapiead.azurewebsites.net/PasswordManager/api/Users/find?phoneID=";
+
+    base = base + _androidId;
+    var uri = Uri.parse(base);
+
+    final response = await http.get(uri);
+    final body = response.body;
+    var json;
+
+    if (body == "No user found with that phone") {
+      account = false;
+    } else {
+      json = jsonDecode(body);
+      account = true;
+    }
+
+    setState(() {
+      if (!account) {
+        print("No account.");
+        showDialog(
+            context: context,
+            builder: ((context) => AlertDialog(
+                title: Text("New Account?"),
+                content: Row(
+                  children: [
+                    GestureDetector(
+                      onTap: () {
+                        Navigator.pop(context);
+                      },
+                      child: Container(
+                        height: 50,
+                        width: 100,
+                        decoration: BoxDecoration(
+                          color: Colors.red[400],
+                          borderRadius: BorderRadius.circular(20),
+                        ),
+                        child: const Align(
+                            alignment: Alignment.center,
+                            child: Text("Cancel",
+                                style: TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 18,
+                                  fontWeight: FontWeight.bold,
+                                ))),
+                      ),
+                    ),
+                    Spacer(),
+                    GestureDetector(
+                      onTap: () {
+                        Navigator.pop(context);
+                        createUser();
+                      },
+                      child: Container(
+                        height: 50,
+                        width: 100,
+                        decoration: BoxDecoration(
+                          color: Colors.green[400],
+                          borderRadius: BorderRadius.circular(20),
+                        ),
+                        child: const Align(
+                            alignment: Alignment.center,
+                            child: Text("Create",
+                                style: TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 18,
+                                  fontWeight: FontWeight.bold,
+                                ))),
+                      ),
+                    ),
+                  ],
+                ))));
+      } else {
+        StatusAlert.show(
+          context,
+          duration: const Duration(seconds: 2),
+          subtitle: "Login Successful!",
+          configuration: const IconConfiguration(
+              icon: Icons.check_circle_rounded, color: Colors.green),
+          maxWidth: 250,
+        );
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+              builder: (context) => UserHomePage(
+                    androidId: json['phoneid'],
+                    userphone: _userphone.text.trim(),
+                  )),
+        );
+      }
+    });
+  }
+
+  void createUser() async {
+    bool created = false;
+
+    String? base =
+        "https://passwordmanagerapiead.azurewebsites.net/PasswordManager/api/Users/add?phoneID=";
+
+    base = base + _androidId;
+    var uri = Uri.parse(base);
+
+    final response = await http.post(uri);
+    final body = response.body;
+    print(body);
+
+    if (body != "User added") {
+      created = false;
+    } else {
+      created = true;
+    }
+
+    print(created);
+
+    setState(() {
+      if (created) {
+        StatusAlert.show(
+          context,
+          duration: const Duration(seconds: 2),
+          subtitle: "New User Created!",
+          configuration: const IconConfiguration(
+              icon: Icons.check_circle_rounded, color: Colors.green),
+          maxWidth: 250,
+        );
+        userLogin();
+      } else {
+        showDialog(
+            context: context,
+            builder: (context) =>
+                AlertDialog(title: Text("Error creating account.")));
+      }
     });
   }
 
@@ -114,7 +254,6 @@ class _MyHomePageState extends State<MyHomePage> {
                   decoration: const InputDecoration(
                     border: OutlineInputBorder(),
                     hintText: 'Enter your phone number..',
-                    
                   ),
                 ),
               ),
@@ -123,14 +262,7 @@ class _MyHomePageState extends State<MyHomePage> {
               padding: const EdgeInsets.only(top: 10),
               child: GestureDetector(
                 onTap: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                        builder: (context) => UserHomePage(
-                          userphone: _userphone.text.trim(),
-                          androidId: _androidId,
-                        )),
-                  );
+                  userLogin();
                 },
                 child: Container(
                   height: 50,

--- a/password_manager_client/lib/user_home.dart
+++ b/password_manager_client/lib/user_home.dart
@@ -4,7 +4,8 @@ import 'package:flutter/src/widgets/placeholder.dart';
 import 'package:password_manager_client/user_settings.dart';
 
 class UserHomePage extends StatefulWidget {
-  const UserHomePage({super.key, required this.userphone, required this.androidId});
+  const UserHomePage(
+      {super.key, required this.userphone, required this.androidId});
   final String userphone;
   final String? androidId;
 
@@ -13,6 +14,7 @@ class UserHomePage extends StatefulWidget {
 }
 
 class _UserHomePageState extends State<UserHomePage> {
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -103,15 +105,15 @@ class _UserHomePageState extends State<UserHomePage> {
         Padding(
           padding: const EdgeInsets.all(10),
           child: GestureDetector(
-            onTap: (){
+            onTap: () {
               Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                        builder: (context) => UserSettingsPage(
+                context,
+                MaterialPageRoute(
+                    builder: (context) => UserSettingsPage(
                           androidId: widget.androidId,
                           phonenumber: widget.userphone,
                         )),
-                  );
+              );
             },
             child: Container(
                 height: 80,
@@ -139,16 +141,6 @@ class _UserHomePageState extends State<UserHomePage> {
                     ))),
           ),
         ),
-        // DONT FORGET TO REMOVE THIS !!
-        const SizedBox(
-            height: 200,
-            child: Padding(
-              padding: EdgeInsets.only(top: 100),
-              child: Text(
-                "Password Manager is powered by Coffee and ElfBar",
-                style: TextStyle(fontStyle: FontStyle.italic),
-              ),
-            )),
       ]),
     );
   }

--- a/password_manager_client/pubspec.lock
+++ b/password_manager_client/pubspec.lock
@@ -73,6 +73,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  flare_flutter:
+    dependency: transitive
+    description:
+      name: flare_flutter
+      sha256: "99d63c60f00fac81249ce6410ee015d7b125c63d8278a30da81edf3317a1f6a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -96,6 +104,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  http:
+    dependency: "direct main"
+    description:
+      name: http
+      sha256: "6aa2946395183537c8b880962d935877325d6a09a2867c3970c05c0fed6ac482"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.13.5"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.2"
   js:
     dependency: transitive
     description:
@@ -221,6 +245,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.11.0"
+  status_alert:
+    dependency: "direct main"
+    description:
+      name: status_alert
+      sha256: "220ce6c1400d19d817665ac5a87f772e87c901677ac37b93320f4764edf4d23f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   stream_channel:
     dependency: transitive
     description:
@@ -253,6 +285,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.4.16"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.1"
   vector_math:
     dependency: transitive
     description:

--- a/password_manager_client/pubspec.yaml
+++ b/password_manager_client/pubspec.yaml
@@ -29,6 +29,8 @@ dependencies:
 
   cupertino_icons: ^1.0.2
   platform_device_id: ^1.0.1
+  http: ^0.13.5
+  status_alert: ^1.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
@RhysMcCabe 

The endpoints for both logging in as an existing user and creating a new user are working from front end. There are two possible paths for the user when they click proceed on the home page. Here they are with screenshots:

1. If the user's androidId is already in the database they are automatically logged in to the application as seen below
<img width="1680" alt="Screenshot 2023-04-18 at 00 49 02" src="https://user-images.githubusercontent.com/53425707/232635996-02c2cd26-fbc3-404a-99b0-a299408d75e9.png">

2. If the users androidId isn't found in the database then they are greeted with a pop up modal as below. They are show options to create or cancel.
<img width="1680" alt="Screenshot 2023-04-18 at 00 50 08" src="https://user-images.githubusercontent.com/53425707/232636099-812c0b5d-8dde-474c-8389-cf356c083790.png">

3. If user selects 'create' their account is created and they are automatically logged into the application
<img width="1680" alt="Screenshot 2023-04-18 at 00 58 36" src="https://user-images.githubusercontent.com/53425707/232636240-4e79a3a2-47a6-4a45-af1b-f4cea06a614c.png">
<img width="1680" alt="Screenshot 2023-04-18 at 00 58 51" src="https://user-images.githubusercontent.com/53425707/232636264-edbf63aa-3bba-4459-9484-1febe33ed3d9.png">

** We can see the users are successfully created here in the database
<img width="1680" alt="Screenshot 2023-04-18 at 01 08 03" src="https://user-images.githubusercontent.com/53425707/232636532-3ced8e76-e2b1-4643-971f-39f8e80bb019.png">

**Some notes:**

- Will change the 'Welcome Back' message to something different if the user is new
- Due to us using an emulator the androidId would be the same every time we try login, hence the need to hardcode 'SomethingNew3', 'SomethingNew4' etc. as the androidId's



