### PR TITLE
added delete all and changed text for adding an existing password

### DIFF
--- a/password_manager_client/lib/add_password.dart
+++ b/password_manager_client/lib/add_password.dart
@@ -38,7 +38,7 @@ class _AddUserPasswordPageState extends State<AddUserPasswordPage> {
         StatusAlert.show(
           context,
           duration: const Duration(seconds: 2),
-          subtitle: "Password added for ${_passwordNameController.text.trim()}",
+          subtitle: response.body,
           configuration: const IconConfiguration(
               icon: Icons.check_circle_rounded, color: Colors.green),
           maxWidth: 250,

--- a/password_manager_client/lib/all_passwords.dart
+++ b/password_manager_client/lib/all_passwords.dart
@@ -33,6 +33,38 @@ class _ViewAllPasswordsPageState extends State<ViewAllPasswordsPage> {
     });
   }
 
+  void deleteAllPasswords() async {
+    var url =
+        "https://passwordmanagerapiead.azurewebsites.net/PasswordManager/api/Password/remove/all?phoneId=";
+
+    url = url + widget.androidId;
+    var uri = Uri.parse(url);
+    final response = await http.delete(uri);
+
+    setState(() {
+      allPasswords = [];
+    });
+
+    // Show response message in an alert dialog
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('Delete All Passwords?'),
+          content: Text(response.body),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+              child: const Text('OK'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
   @override
   void initState() {
     super.initState();
@@ -47,8 +79,7 @@ class _ViewAllPasswordsPageState extends State<ViewAllPasswordsPage> {
         title: const Text("View All Passwords"),
         backgroundColor: Colors.red[800],
       ),
-      body: 
-      !fetched
+      body: !fetched
           ? const CircularProgressIndicator()
           : ListView.builder(
               itemCount: allPasswords.length,
@@ -63,7 +94,7 @@ class _ViewAllPasswordsPageState extends State<ViewAllPasswordsPage> {
                       height: 50,
                       child: Row(children: [
                         Padding(
-                          padding: const EdgeInsets.only(left:10),
+                          padding: const EdgeInsets.only(left: 10),
                           child: Text(allPasswords[index]['passwordName']),
                         ),
                         const Spacer(),
@@ -74,6 +105,50 @@ class _ViewAllPasswordsPageState extends State<ViewAllPasswordsPage> {
                       ])),
                 );
               }),
+      floatingActionButton: allPasswords.length > 0
+          ? FloatingActionButton(
+              onPressed: () {
+                showDialog(
+                  context: context,
+                  builder: (BuildContext context) {
+                    return AlertDialog(
+                      title: const Text('Delete All Passwords'),
+                      content: const Text(
+                          'Are you sure you want to delete all your passwords? This cannot be undone!'),
+                      actions: <Widget>[
+                        TextButton(
+                          onPressed: () {
+                            Navigator.of(context).pop();
+                          },
+                          child: const Text('Cancel'),
+                        ),
+                        Container(
+                          decoration: BoxDecoration(
+                            borderRadius: BorderRadius.circular(10),
+                            color: Colors.red,
+                          ),
+                          child: TextButton(
+                            onPressed: () {
+                              Navigator.of(context).pop();
+                              deleteAllPasswords();
+                            },
+                            child: const Text(
+                              'DELETE ALL',
+                              style: TextStyle(
+                                color: Colors.white,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    );
+                  },
+                );
+              },
+              tooltip: 'Delete All Passwords',
+              child: const Icon(Icons.delete),
+            )
+          : null,
     );
   }
 }


### PR DESCRIPTION
**Small update on the adding a new password page**
- Before if you added a password that already existed it would say 'Password added etc...'
- I changed it to print the API response which will tell you if a password has been created or updated.
![Updating](https://user-images.githubusercontent.com/71702191/233156159-23695029-3b8e-47ae-a9af-7c360e608bff.PNG)

**Added deleteAll button**
- If a user has passwords a trash icon will show
- Confirmation dialogue to confirm
- Then will delete with a confirmation of deletion (I actually want to change this to how the others are done, just realizing now).


![DeleteAll](https://user-images.githubusercontent.com/71702191/233156820-08c2f421-0b41-4455-ba83-0d74e26b68a4.PNG)
![DeleteAll2](https://user-images.githubusercontent.com/71702191/233156838-1cc7a671-ebf0-4f5f-a269-53aceaa960e1.PNG)
